### PR TITLE
[Resolve #1334] Add a dump vars command

### DIFF
--- a/sceptre/cli/dump.py
+++ b/sceptre/cli/dump.py
@@ -78,10 +78,7 @@ def dump_config(ctx, path):
     plan = SceptrePlan(context)
     responses = plan.dump_vars()
 
-    output = []
-    for stack, vars in responses.items():
-        output.append({stack.external_name: vars})
-
+    output = [vars for _, vars in responses.items()]
     output_format = "json" if context.output_format == "json" else "yaml"
 
     for vars in output:

--- a/sceptre/cli/dump.py
+++ b/sceptre/cli/dump.py
@@ -53,3 +53,36 @@ def dump_config(ctx, path):
     else:
         for config in output:
             write(config, output_format)
+
+
+@dump_group.command(name="vars")
+@click.argument("path")
+@click.pass_context
+@catch_exceptions
+def dump_config(ctx, path):
+    """
+    Dump the template vars.
+    \f
+
+    :param path: Path to execute the command on or path to stack group
+    """
+    context = SceptreContext(
+        command_path=path,
+        command_params=ctx.params,
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        output_format=ctx.obj.get("output_format"),
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+    )
+    plan = SceptrePlan(context)
+    responses = plan.dump_vars()
+
+    output = []
+    for stack, vars in responses.items():
+        output.append({stack.external_name: vars})
+
+    output_format = "json" if context.output_format == "json" else "yaml"
+
+    for vars in output:
+        write(vars, output_format)

--- a/sceptre/cli/dump.py
+++ b/sceptre/cli/dump.py
@@ -59,7 +59,7 @@ def dump_config(ctx, path):
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
-def dump_config(ctx, path):
+def dump_vars(ctx, path):
     """
     Dump the template vars.
     \f

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -602,6 +602,7 @@ class ConfigReader(object):
             obsolete=config.get("obsolete", False),
             stack_group_config=parsed_stack_group_config,
             config=config,
+            vars=self.templating_vars,
         )
 
         del self.templating_vars["stack_group_config"]

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -1150,3 +1150,10 @@ class StackActions:
         Dump the config for a stack.
         """
         return self.stack.config
+
+    @add_stack_hooks
+    def dump_vars(self):
+        """
+        Dump the vars for a stack.
+        """
+        return self.stack.vars

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -440,3 +440,10 @@ class SceptrePlan(object):
         """
         self.resolve(command=self.dump_config.__name__)
         return self._execute(*args)
+
+    def dump_vars(self, *args):
+        """
+        Dump the vars for a stack.
+        """
+        self.resolve(command=self.dump_vars.__name__)
+        return self._execute(*args)

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -123,6 +123,10 @@ class Stack:
            If not supplied, Sceptre uses default value (3600 seconds)
 
     :param stack_group_config: The StackGroup config for the Stack
+
+    :param config: The complete config for the stack. Used by dump config.
+
+    :param vars: The complete templating vars for the Stack. Used by dump vars.
     """
 
     parameters = ResolvableContainerProperty("parameters")
@@ -195,6 +199,7 @@ class Stack:
         obsolete=False,
         stack_group_config: dict = {},
         config: dict = {},
+        vars: dict = {},
     ):
         self.logger = logging.getLogger(__name__)
 
@@ -213,6 +218,7 @@ class Stack:
         )
         self.stack_group_config = stack_group_config or {}
         self.config = config or {}
+        self.vars = vars or {}
         self.stack_timeout = stack_timeout
         self.profile = profile
         self.template_key_prefix = template_key_prefix

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -2,7 +2,7 @@
 
 import errno
 import os
-from unittest.mock import patch, sentinel, MagicMock, ANY
+from unittest.mock import patch, sentinel, MagicMock
 
 import pytest
 import yaml
@@ -323,10 +323,10 @@ class TestConfigReader(object):
                 "required_version": ">1.0",
                 "template_bucket_name": "stack_group_template_bucket_name",
                 "custom_key": "custom_value",
-                "dependencies": ["child/level",
-                "top/level"],
+                "dependencies": ["child/level", "top/level"],
                 "template": {"path": "path/to/template"},
-                "parameters": {"param1": "val1"}},
+                "parameters": {"param1": "val1"},
+            },
             vars={
                 "var": {},
                 "project_path": self.context.project_path,
@@ -337,8 +337,8 @@ class TestConfigReader(object):
                 "required_version": ">1.0",
                 "template_bucket_name": "stack_group_template_bucket_name",
                 "custom_key": "custom_value",
-                "dependencies": ["top/level"]
-            }
+                "dependencies": ["top/level"],
+            },
         )
 
         assert stacks == ({sentinel.stack}, {sentinel.stack})

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -280,7 +280,7 @@ class TestConfigReader(object):
         self.context.project_path = os.path.abspath("tests/fixtures-vpc")
         self.context.command_path = "account/stack-group/region/vpc.yaml"
         stacks = ConfigReader(self.context).construct_stacks()
-        mock_Stack.assert_any_call(
+        mock_Stack.assert_called_once_with(
             name="account/stack-group/region/vpc",
             project_code="account_project_code",
             template_path=None,
@@ -314,7 +314,31 @@ class TestConfigReader(object):
                 "project_path": self.context.project_path,
                 "custom_key": "custom_value",
             },
-            config=ANY,
+            config={
+                "project_path": self.context.project_path,
+                "stack_group_path": "account/stack-group/region",
+                "profile": "account_profile",
+                "project_code": "account_project_code",
+                "region": "region_region",
+                "required_version": ">1.0",
+                "template_bucket_name": "stack_group_template_bucket_name",
+                "custom_key": "custom_value",
+                "dependencies": ["child/level",
+                "top/level"],
+                "template": {"path": "path/to/template"},
+                "parameters": {"param1": "val1"}},
+            vars={
+                "var": {},
+                "project_path": self.context.project_path,
+                "stack_group_path": "account/stack-group/region",
+                "profile": "account_profile",
+                "project_code": "account_project_code",
+                "region": "region_region",
+                "required_version": ">1.0",
+                "template_bucket_name": "stack_group_template_bucket_name",
+                "custom_key": "custom_value",
+                "dependencies": ["top/level"]
+            }
         )
 
         assert stacks == ({sentinel.stack}, {sentinel.stack})


### PR DESCRIPTION
## Description

Add a `dump vars` command. This command dumps the compiled `templating_vars` for the purpose of additional debugging information.

## Example

<img width="1098" alt="Screen Shot 2023-04-23 at 1 25 39 pm" src="https://user-images.githubusercontent.com/2305330/233819279-5feeb2aa-51fe-4bef-af4f-dadd753e7ef0.png">

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
