### PR TITLE
Treating None like its not there

### DIFF
--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -167,12 +167,15 @@ class StackDiffer(Generic[DiffType]):
         """
         formatted_parameters = {}
         for key, value in stack.parameters.items():
+            # When boto3 receives "None" for a cloudformation parameter, it treats it as if the
+            # value is not passed at all. To be consistent in our diffing, we need to skip Nones
+            # altogether.
+            if value is None:
+                continue
+
             if isinstance(value, list):
                 value = ",".join(item.rstrip("\n") for item in value)
-            if isinstance(value, str):
-                formatted_parameters[key] = value.rstrip("\n")
-            elif value is None:
-                formatted_parameters[key] = ""
+            formatted_parameters[key] = value.rstrip("\n")
 
         return formatted_parameters
 

--- a/tests/test_diffing/test_stack_differ.py
+++ b/tests/test_diffing/test_stack_differ.py
@@ -158,7 +158,7 @@ class TestStackDiffer:
     def expected_generated_config(self):
         return StackConfiguration(
             stack_name=self.external_name,
-            parameters=self.parameters_on_stack_config,
+            parameters=deepcopy(self.parameters_on_stack_config),
             stack_tags=deepcopy(self.tags),
             notifications=deepcopy(self.notifications),
             cloudformation_service_role=self.cloudformation_service_role,
@@ -168,7 +168,7 @@ class TestStackDiffer:
     def expected_deployed_config(self):
         return StackConfiguration(
             stack_name=self.external_name,
-            parameters=self.deployed_parameters,
+            parameters=deepcopy(self.deployed_parameters),
             stack_tags=deepcopy(self.deployed_tags),
             notifications=deepcopy(self.deployed_notification_arns),
             cloudformation_service_role=self.deployed_cloudformation_service_role,
@@ -332,15 +332,15 @@ class TestStackDiffer:
             self.expected_deployed_config, self.expected_generated_config
         )
 
-    def test_diff__deployed_stack_has_default_values_one_of_them_none__compares_different_configs(
+    def test_diff__generated_stack_has_none_for_parameter_value__its_treated_like_its_not_specified(
         self,
     ):
-        self.deployed_parameters["new"] = "default value"
-        self.deployed_parameter_defaults["new"] = None
-        self.parameters_on_stack_config["new"] = ""
+        self.parameters_on_stack_config["new"] = None
+        expected_generated = self.expected_generated_config
+        del expected_generated.parameters["new"]
         self.differ.diff(self.actions)
         self.command_capturer.compare_stack_configurations.assert_called_with(
-            self.expected_deployed_config, self.expected_generated_config
+            self.expected_deployed_config, expected_generated
         )
 
     def test_diff__stack_exists_with_same_config_but_template_does_not__compares_identical_configs(


### PR DESCRIPTION
This solves the issue by treating "None" values on the local config as if they weren't passed at all. Since that's exactly how CloudFormation treats them, they just get removed from the diff. This has the proper effect. 